### PR TITLE
KCL-9004 - Add support for displayTimeZone of DateTime element

### DIFF
--- a/js/management-api-v2/PutVariant.js
+++ b/js/management-api-v2/PutVariant.js
@@ -32,7 +32,8 @@ const response = await client.upsertLanguageVariant()
         element: {
             codename: 'post_date'
         },
-        value: '2014-11-07T00:00:00Z'
+        value: '2014-11-07T00:00:00Z',
+        display_timezone: "Australia/Sydney"
     }),
     builder.textElement({
       element: {

--- a/js/management-api-v2/PutVariantPublishOrSchedule.js
+++ b/js/management-api-v2/PutVariantPublishOrSchedule.js
@@ -16,7 +16,8 @@ const response = await client.publishLanguageVariant()
   // .byLanguageCodename('es-mx')
   // To schedule publish date, use .withData({scheduled_to: 'datetime-to-publish-at'})
   .withData({
-    scheduled_to: '2038-01-19T04:14:08+01:00'
+    scheduled_to: '2038-01-19T04:14:08+01:00',
+    display_timezone: "Australia/Sydney"
   })
   // To publish now, use .withoutData()
   .toPromise();

--- a/js/management-api-v2/PutVariantUnpublishAndArchive.js
+++ b/js/management-api-v2/PutVariantUnpublishAndArchive.js
@@ -16,7 +16,8 @@ const response = await client.unpublishLanguageVariant()
   .byLanguageCodename('es-mx')
   // To schedule unpublish date, use .withData({scheduled_to: 'datetime-to-unpublish-at'})
   .withData({
-    scheduled_to: '2038-01-19T04:14:08+01:00'
+    scheduled_to: '2038-01-19T04:14:08+01:00',
+    display_timezone: "Australia/Sydney"
   })
   // To unpublish now, use .withoutData()
   .toPromise();

--- a/net/management-api-v2/PutVariant.cs
+++ b/net/management-api-v2/PutVariant.cs
@@ -33,7 +33,8 @@ var response = await client.UpsertLanguageVariantAsync(
             new DateTimeElement
             {
                 Element = Reference.ByCodename("post_date"),
-                Value = DateTime.Parse("2014-11-07T00:00:00Z")
+                Value = DateTime.Parse("2014-11-07T00:00:00Z"),
+                DisplayTimeZone = "Australia/Sydney"
             },
             new TextElement
             {

--- a/net/management-api-v2/PutVariantPublishOrSchedule.cs
+++ b/net/management-api-v2/PutVariantPublishOrSchedule.cs
@@ -21,6 +21,7 @@ await client.PublishLanguageVariantAsync(identifier);
 // Scheduled publish
 await client.SchedulePublishingOfLanguageVariantAsync(identifier, new ScheduleModel
 {
-    ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00")
+    ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+    DisplayTimeZone = "Australia/Sydney"
 });
 // EndDocSection

--- a/net/management-api-v2/PutVariantUnpublishAndArchive.cs
+++ b/net/management-api-v2/PutVariantUnpublishAndArchive.cs
@@ -21,6 +21,7 @@ await client.UnpublishLanguageVariantAsync(identifier);
 // Scheduled unpublish
 await client.ScheduleUnpublishingOfLanguageVariantAsync(identifier, new ScheduleModel
 {
-    ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00")
+    ScheduleTo = DateTime.Parse("2038-01-19T04:14:08+01:00"),
+    DisplayTimeZone = "Australia/Sydney"
 });
 // EndDocSection

--- a/rest/management-api-v2/PutVariant.curl
+++ b/rest/management-api-v2/PutVariant.curl
@@ -28,7 +28,8 @@ curl --request PUT \
       "element":{
         "codename":"post_date"
       },
-      "value":"2014-11-07T00:00:00Z"
+      "value":"2014-11-07T00:00:00Z",
+      "display_timezone":"Australia/Sydney"
     },
     {
       "element":{


### PR DESCRIPTION
### Motivation

Provide GitHub issue or Jira issue URL. Add more explanation if necessary.

A new property "displayTimeZone" was added to DateTime element which affects following MAPI endpoints:

Publish or schedule a language variant
Unpublish or schedule unpublishing of a language variant
Upsert a language variant

- https://kentico.atlassian.net/browse/KCL-9004?atlOrigin=eyJpIjoiMjIyZGYwYjY4Nzk5NDdkMDg0NzBkMmY2ZDhhMjM3MzIiLCJwIjoiaiJ9

### Context

Add the following information:

* When do you need the code to go public? Provide a release date and/or explanation.
**14.9.2022**

* Is the pull request complete and ready for review? **No**
  * If not, set the [PR as draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).

**Please wait until the SDK merge request is finished**
https://github.com/kontent-ai/management-sdk-net/pull/204

Contact Marek Radiměřský or team Easy when needed.